### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: imgclone
 
 INCL=-I/usr/include
-LINK=-L/usr/lib -L/usr/local/lib -I/usr/lib/arm-linux-gnueabihf -lpthread
+LINK=-L/usr/lib -L/usr/local/lib -I/usr/lib/arm-linux-gnueabihf -pthread
 CC=gcc -g $(INCL)
 
 imgclone: imgclone.c


### PR DESCRIPTION
-lpthread only links the pthread library
-pthread will link the library and configure the compilation for threads

-> error fix for:
undefined reference to `pthread_create'
undefined reference to `pthread_join'