### PR TITLE
Fix compile errors while compling with '-Werror -Wextra -Wall'

### DIFF
--- a/imgclone.c
+++ b/imgclone.c
@@ -98,7 +98,7 @@ static int get_string2 (char *cmd, char *name, int print_cmd_line)
 
 static int get_string (char *cmd, char *name)
 {
-    get_string2(cmd, name, 1);
+    return get_string2(cmd, name, 1);
 }
 
 
@@ -141,7 +141,7 @@ static void escape_shell_arg(char * dst_buffer, const char * src_buffer){
 	while (*src_buffer!='\0'){
 		if (*src_buffer=='"' || *src_buffer=='\\'){
 			*dst_buffer='\\';
-			*dst_buffer++;
+			dst_buffer++;
 		}
 		*dst_buffer=*src_buffer;
 		src_buffer++;


### PR DESCRIPTION
gcc -g -I/usr/include -L/usr/lib -L/usr/local/lib -I/usr/lib/arm-linux-gnueabihf -pthread -Werror -Wextra -Wall imgclone.c -o imgclone
imgclone.c: In function ‘get_string’:
imgclone.c:102:1: error: no return statement in function returning non-void [-Werror=return-type]
 }
 ^
imgclone.c: In function ‘escape_shell_arg’:
imgclone.c:144:4: error: value computed is not used [-Werror=unused-value]
    *dst_buffer++;
    ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:9: imgclone] Error 1